### PR TITLE
Allow the repository to be dependency injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ options:
   --port PORT
 ```
 
-If multiple repositories are provided, the ``PrioritySelectedProjectsRepository`` component will be used to
+The simplest example of this is to simply mirror the Python Package Index:
+
+```bash
+python -m simple_repository_server https://pypi.org/simple/
+```
+
+However, if multiple repositories are provided, the ``PrioritySelectedProjectsRepository`` component will be used to
 combine them together in a way that mitigates the [dependency confusion attack](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610).
 
 The server handles PEP-691 content negotiation to serve either HTML or JSON formats.
@@ -55,7 +61,7 @@ For cases when control of the repository configuration is required, and where de
 ASGI environment need more precise control, it is expected that ``simple-repository-server`` is used
 as a library instead of a CLI.
 
-Currently the API for this functionality is under development, and will certainly change in the
+Currently, the API for this functionality is under development, and will certainly change in the
 future.
 
 ## License and Support

--- a/simple_repository_server/__main__.py
+++ b/simple_repository_server/__main__.py
@@ -67,7 +67,7 @@ def create_app(repository_urls: list[str]) -> fastapi.FastAPI:
     async def lifespan(app: FastAPI) -> typing.AsyncIterator[None]:
         async with httpx.AsyncClient() as http_client:
             repo = create_repository(repository_urls, http_client)
-            app.include_router(simple.build_router(repo, http_client), prefix="")
+            app.include_router(simple.build_router(repo, http_client=http_client))
             yield
 
     app = FastAPI(

--- a/simple_repository_server/routers/simple.py
+++ b/simple_repository_server/routers/simple.py
@@ -115,15 +115,13 @@ def build_router(
     ) -> Response:
         normed_prj_name = packaging.utils.canonicalize_name(project_name)
         if normed_prj_name != project_name:
-            new_path_params = request.path_params.copy()
-            new_path_params["project_name"] = normed_prj_name
+            # Update the original path params with the normed name.
+            path_params = request.path_params | {'project_name': normed_prj_name}
             correct_url = utils.relative_url_for(
                 request=request,
                 name="simple_project_page",
-                **new_path_params,
+                **path_params,
             )
-            if request.url.query:
-                correct_url = correct_url + "?" + request.url.query
             return RedirectResponse(
                 url=correct_url,
                 status_code=301,

--- a/simple_repository_server/routers/simple.py
+++ b/simple_repository_server/routers/simple.py
@@ -59,9 +59,29 @@ def get_response_format(
 
 
 def build_router(
-    repository: SimpleRepository,
+    resource_repository: SimpleRepository,
+    *,
     http_client: httpx.AsyncClient,
+    prefix: str = "/simple/",
+    repo_factory: typing.Optional[typing.Callable[..., SimpleRepository]] = None,
 ) -> APIRouter:
+    """
+    Build a FastAPI router for the given repository and http_client.
+
+    Note that for the simple end-points, the repository is an injected
+    dependency, meaning that you can add your own dependencies into the repository
+    (see the test_repo_dependency_injection for an example of this).
+
+    """
+    if not prefix.endswith("/"):
+        raise ValueError("Prefix must end in '/'")
+
+    if repo_factory is None:
+        # If no repo factory is provided, use the same repository that we want to
+        # use for resource handling.
+        def repo_factory() -> SimpleRepository:
+            return resource_repository
+
     simple_router = APIRouter(
         tags=["simple"],
         default_response_class=HTMLResponse,
@@ -69,9 +89,10 @@ def build_router(
     #: To be fixed by https://github.com/tiangolo/fastapi/pull/2763
     get = functools.partial(simple_router.api_route, methods=["HEAD", "GET"])
 
-    @get("/simple/")
+    @get(prefix)
     async def project_list(
         response_format: typing.Annotated[content_negotiation.Format, Depends(get_response_format)],
+        repository: typing.Annotated[SimpleRepository, Depends(repo_factory)],
     ) -> Response:
         project_list = await repository.get_project_list()
 
@@ -85,20 +106,26 @@ def build_router(
             media_type=response_format.value,
         )
 
-    @get("/simple/{project_name}/")
+    @get(prefix + "{project_name}/")
     async def simple_project_page(
-        project_name: str,
         request: fastapi.Request,
+        project_name: str,
+        repository: typing.Annotated[SimpleRepository, Depends(repo_factory)],
         response_format: typing.Annotated[content_negotiation.Format, Depends(get_response_format)],
     ) -> Response:
         normed_prj_name = packaging.utils.canonicalize_name(project_name)
         if normed_prj_name != project_name:
+            new_path_params = request.path_params.copy()
+            new_path_params["project_name"] = normed_prj_name
+            correct_url = utils.relative_url_for(
+                request=request,
+                name="simple_project_page",
+                **new_path_params,
+            )
+            if request.url.query:
+                correct_url = correct_url + "?" + request.url.query
             return RedirectResponse(
-                url=utils.relative_url_for(
-                    request=request,
-                    name="simple_project_page",
-                    project_name=normed_prj_name,
-                ),
+                url=correct_url,
                 status_code=301,
             )
 
@@ -107,6 +134,11 @@ def build_router(
         except errors.PackageNotFoundError as e:
             raise HTTPException(404, str(e))
 
+        # Point all resource URLs to this router. The router may choose to redirect these
+        # back to the original source, but this means that all resource requests go through
+        # this server (it may be desirable to be able to disable this behaviour in the
+        # future, though it would mean that there is the potential for a SimpleRepository
+        # to have implemented a resource handler, yet it never sees the request).
         project_releases = utils.replace_urls(package_releases, project_name, request)
 
         serialized_project_page = serializer.serialize(
@@ -126,12 +158,12 @@ def build_router(
     ) -> fastapi.Response:
 
         req_ctx = model.RequestContext(
-            repository,
+            resource_repository,
             context=dict(request.headers.items()),
         )
 
         try:
-            resource = await repository.get_resource(
+            resource = await resource_repository.get_resource(
                 project_name,
                 resource_name,
                 request_context=req_ctx,

--- a/simple_repository_server/tests/api/test_simple_router.py
+++ b/simple_repository_server/tests/api/test_simple_router.py
@@ -30,7 +30,7 @@ def mock_repo() -> mock.AsyncMock:
 def client(tmp_path: pathlib.PosixPath, mock_repo: mock.AsyncMock) -> typing.Generator[TestClient, None, None]:
     app = FastAPI()
     http_client = httpx.AsyncClient()
-    app.include_router(simple_router.build_router(mock_repo, http_client))
+    app.include_router(simple_router.build_router(mock_repo, http_client=http_client))
 
     with TestClient(app) as test_client:
         yield test_client
@@ -132,7 +132,7 @@ def test_get_resource__remote(mock_repo: mock.AsyncMock, httpx_mock: HTTPXMock) 
     )
     http_client = httpx.AsyncClient()
     app = FastAPI()
-    app.include_router(simple_router.build_router(mock_repo, http_client))
+    app.include_router(simple_router.build_router(mock_repo, http_client=http_client))
     client = TestClient(app)
 
     response = client.get("/resources/numpy/numpy-1.0-ciao.whl", follow_redirects=False)

--- a/simple_repository_server/tests/integration/test_repo_dependency_injection.py
+++ b/simple_repository_server/tests/integration/test_repo_dependency_injection.py
@@ -1,0 +1,151 @@
+import fastapi
+from fastapi.testclient import TestClient
+import httpx
+import pytest
+from simple_repository import model
+from simple_repository.components.core import SimpleRepository
+from simple_repository.tests.components.fake_repository import FakeRepository
+
+from simple_repository_server.routers import simple
+
+
+def create_app(repo: SimpleRepository, repo_factory) -> fastapi.FastAPI:
+    app = fastapi.FastAPI(openapi_url=None)
+
+    http_client = httpx.AsyncClient()
+    app.include_router(
+        simple.build_router(
+            repo,
+            http_client=http_client,
+            prefix="/snapshot/{cutoff_date}/",
+            repo_factory=repo_factory,
+        ),
+    )
+
+    return app
+
+
+@pytest.fixture
+def fake_repo() -> SimpleRepository:
+    return FakeRepository(
+        project_list=model.ProjectList(model.Meta("1.0"), [model.ProjectListElement("foo-bar")]),
+        project_pages=[
+            model.ProjectDetail(
+                model.Meta('1.1'),
+                "foo-bar",
+                files=(
+                    model.File("foo_bar-2.0-any.whl", "", {}, size=1),
+                    model.File("foo_bar-3.0-any.whl", "", {}, size=1),
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def empty_repo() -> SimpleRepository:
+    return FakeRepository()
+
+
+class SimpleFactoryWithParams:
+    def __init__(self, repo: SimpleRepository):
+        self.cutoff_date = None
+        self.repo = repo
+
+    def __call__(self, cutoff_date: str) -> SimpleRepository:
+        self.cutoff_date = cutoff_date
+        # In this factory, just return the original repo, but we return a
+        # more specific repo here.
+        return self.repo
+
+
+@pytest.fixture
+def repo_factory(fake_repo: SimpleRepository) -> SimpleFactoryWithParams:
+    return SimpleFactoryWithParams(repo=fake_repo)
+
+
+@pytest.mark.asyncio
+async def test_repo_with_dependency_injection__projects_list(
+        empty_repo: SimpleRepository,
+        repo_factory: SimpleFactoryWithParams,
+):
+    app = create_app(empty_repo, repo_factory=repo_factory)
+    client = TestClient(app)
+    response = client.get("/snapshot/2020-10-12/?format=application/vnd.pypi.simple.v1+json")
+
+    # Check that the factory was called with the expected args.
+    assert repo_factory.cutoff_date == "2020-10-12"
+
+    # And that the response is not for the empty repo, but the factory one.
+    assert response.status_code == 200
+    assert response.headers['content-type'] == 'application/vnd.pypi.simple.v1+json'
+    assert response.json() == {
+      "meta": {
+        "api-version": "1.0",
+      },
+      "projects": [
+        {
+          "name": "foo-bar",
+        },
+      ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_repo_with_dependency_injection__project_page(
+        empty_repo: SimpleRepository,
+        repo_factory: SimpleFactoryWithParams,
+):
+    app = create_app(empty_repo, repo_factory=repo_factory)
+    client = TestClient(app)
+    response = client.get("/snapshot/2020-10-12/foo-bar/?format=application/vnd.pypi.simple.v1+json")
+
+    # Check that the factory was called with the expected args.
+    assert repo_factory.cutoff_date == "2020-10-12"
+
+    assert response.status_code == 200
+    assert response.headers['content-type'] == 'application/vnd.pypi.simple.v1+json'
+    assert response.json() == {
+      "meta": {
+        "api-version": "1.1",
+      },
+      "name": "foo-bar",
+      "files": [
+        {
+          "filename": "foo_bar-2.0-any.whl",
+          "url": "../../../resources/foo-bar/foo_bar-2.0-any.whl",
+          "hashes": {},
+          "size": 1,
+        },
+        {
+          "filename": "foo_bar-3.0-any.whl",
+          "url": "../../../resources/foo-bar/foo_bar-3.0-any.whl",
+          "hashes": {},
+          "size": 1,
+        },
+      ],
+      "versions": [
+        "2.0",
+        "3.0",
+      ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_repo_with_dependency_injection__project_page__redirect(
+        empty_repo: SimpleRepository,
+        repo_factory: SimpleFactoryWithParams,
+):
+    app = create_app(empty_repo, repo_factory=repo_factory)
+    client = TestClient(app)
+    response = client.get(
+        "/snapshot/2020-10-12/foo_Bar/?format=application/vnd.pypi.simple.v1+json",
+        follow_redirects=False,
+    )
+
+    # Check that the factory was called with the expected args.
+    assert repo_factory.cutoff_date == "2020-10-12"
+
+    assert response.status_code == 301
+    # Ensure that we maintain the querystring.
+    assert response.headers['location'] == '../foo-bar/?format=application/vnd.pypi.simple.v1+json'


### PR DESCRIPTION
Allow the repository to be dependency injected, thus allowing flexible subdependency declarations via FastAPI