### PR TITLE
Redirect to http resources by default

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -51,7 +51,7 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/simple-repository-server
-     
+
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4


### PR DESCRIPTION
#15 relates.

This introduces a binary flag on the router to allow you to toggle between streaming and redirect. Streaming makes sense when you are in an air-gapped environment (the original motivator), or when the server has authentication credentials which the client might not (e.g. https://github.com/simple-repository/simple-repository/issues/35). Redirect makes sense when you are using `simple-repository-server` to handle repository merging (e.g. of public repositories), it would also make `pip`/`uv` cache more efficient (tested: pip shows that it is caching the non-redirected URL, but it actually caches the final URL) as the terminal URL will reach `pip`/`uv` and can be pooled with other requests to the same location (that don't go through `simple-repository-server`.

In the future, I hope that #15 will address the ability to `get_resource` of a byte-stream (irrespective of source), allowing unknown protocols to work seamlessly. In that scenario, I hope the that the stream doesn't start until requested, and that there will be enough context to know that for http resources we might return a redirect response instead. In that world, it would be a component-level behaviour whether streaming is forced or not - if you want to disable redirecting, you simply hide the source URL in your `get_resource` response and the server can do nothing other than streaming. There, this flag would continue to make sense, but would be something we can move down into a component (and eventually remove from the `build_router` function.